### PR TITLE
check for Watson Assistant connection on server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To run the mobile application (using the Xcode iOS Simulator or Android Studio E
     1. **iOS only**: Go to the `ios` directory: `cd ios`.
     1. **iOS only**: Install pod dependencies: `pod install`.
     1. **iOS only**: Return to the `mobile-app` directory: `cd ../`.
-    1. Launch the app in the simulator/emulator: 
+    1. Launch the app in the simulator/emulator:
         - **iOS only**: `npm run ios`
             > **Note**: You should be running at least iOS 13.0. The first time you launch the simulator, you should ensure that you set a Location in the Features menu.
         - **Android only**: `npm run android`

--- a/starter-kit/server-app/lib/assistant.js
+++ b/starter-kit/server-app/lib/assistant.js
@@ -12,6 +12,22 @@ const assistant = new AssistantV2({
   url: apiUrl
 });
 
+checkConnection(assistant)
+
+function checkConnection(assistant){
+  assistant.createSession({
+    assistantId: assistantId
+  })
+    .then(res =>{
+      console.log('✅ Watson Assistant correctly connected!')
+      console.log(res.result.session_id)
+    })
+    .catch(err => {
+      console.log('❌ an error occured while connecting to Watson Assistant. Please check your parameters.')
+      console.log(err)
+    });
+}
+
 const message = (text, sessionId) => {
   if (!assistantId || assistantId === '<assistant_id>') {
     return Promise.reject('ASSISTANT_ID has not been configured.')

--- a/starter-kit/server-app/lib/assistant.js
+++ b/starter-kit/server-app/lib/assistant.js
@@ -26,7 +26,7 @@ function checkConnection(assistant){
       console.log('❌ an error occured while connecting to Watson Assistant. Please check your parameters.')
       console.log(err)
     });
-}
+  }
 
 const message = (text, sessionId) => {
   if (!assistantId || assistantId === '<assistant_id>') {


### PR DESCRIPTION
This PR introduces a quick check on the Watson Assistant connection when starting the server.
Since there is no method for obtaining the connection status, I create a temporary session to make sure that I am able to connect to WA. It's just a workaround.

Attached screenshots show the check on the console.
<img width="656" alt="check_OK" src="https://user-images.githubusercontent.com/2913435/80613642-d63a3b00-8a3d-11ea-8871-5cb751769ddb.png">
<img width="871" alt="check_ERROR" src="https://user-images.githubusercontent.com/2913435/80613682-e225fd00-8a3d-11ea-9263-191997d33446.png">


